### PR TITLE
Fix Celery app initialization

### DIFF
--- a/backend_django/__init__.py
+++ b/backend_django/__init__.py
@@ -1,5 +1,11 @@
-# This will make sure the app is always imported when
-# Django starts so that shared_task will use this app.
-# from .celery import app as celery_app
+"""Initialize Celery when Django starts."""
 
-# __all__ = ('celery_app',)
+# This ensures the Celery app is loaded when Django
+# starts so that the ``shared_task`` decorator uses
+# our configured application. Without this import the
+# tasks fall back to the default Celery app which uses
+# ``pyamqp://guest@localhost//`` and results in connection
+# errors if RabbitMQ is not running.
+from .celery import app as celery_app
+
+__all__ = ("celery_app",)


### PR DESCRIPTION
## Summary
- ensure Celery app is loaded with Django so tasks use Redis

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_684019fcfd34833194b6e3ec89bdc472